### PR TITLE
Fix ESM imports

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
   "editor.formatOnSave": false,
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
+  },
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/README.md
+++ b/README.md
@@ -23,15 +23,99 @@ npm install union-find-ts
 
 ## Usage
 
-
 ```ts
+import { concat, groupBy, lift } from 'ramda'
+import { unionFind, toConnectedGroups } from 'union-find-ts'
 
+enum Center {
+    Head = 1,
+    Ajna,
+    Throat,
+    Identity,
+    Sacral,
+    Root,
+    Spleen,
+    Will,
+    ESP
+}
+interface TestInterface {
+    num: number
+    connected: number[]
+    center: Center
+}
+const allItems: TestInterface[] = [
+    { num: 41, center: Center.Root, connected: [30] },
+    { num: 19, center: Center.Root, connected: [49] },
+    { num: 13, center: Center.Identity, connected: [33] },
+    { num: 49, center: Center.ESP, connected: [19] },
+    { num: 30, center: Center.ESP, connected: [41] },
+    { num: 55, center: Center.ESP, connected: [39] },
+    { num: 37, center: Center.ESP, connected: [40] },
+    { num: 63, center: Center.Head, connected: [4] },
+    { num: 22, center: Center.ESP, connected: [12] },
+    { num: 36, center: Center.ESP, connected: [35] },
+    { num: 25, center: Center.Identity, connected: [51] },
+    { num: 17, center: Center.Ajna, connected: [62] },
+    { num: 21, center: Center.Will, connected: [45] },
+    { num: 51, center: Center.Will, connected: [26] },
+    { num: 42, center: Center.Sacral, connected: [53] },
+    { num: 3, center: Center.Sacral, connected: [60] },
+    { num: 27, center: Center.Sacral, connected: [50] },
+    { num: 24, center: Center.Ajna, connected: [61] },
+    { num: 2, center: Center.Identity, connected: [14] },
+    { num: 23, center: Center.Throat, connected: [43] },
+    { num: 8, center: Center.Throat, connected: [1] },
+    { num: 20, center: Center.Throat, connected: [10, 57, 34] },
+    { num: 16, center: Center.Throat, connected: [48] },
+    { num: 35, center: Center.Throat, connected: [36] },
+    { num: 45, center: Center.Throat, connected: [21] },
+    { num: 12, center: Center.Throat, connected: [22] },
+    { num: 15, center: Center.Identity, connected: [5] },
+    { num: 52, center: Center.Root, connected: [9] },
+    { num: 39, center: Center.Root, connected: [55] },
+    { num: 53, center: Center.Root, connected: [42] },
+    { num: 62, center: Center.Throat, connected: [17] },
+    { num: 56, center: Center.Throat, connected: [11] },
+    { num: 31, center: Center.Throat, connected: [7] },
+    { num: 33, center: Center.Throat, connected: [13] },
+    { num: 7, center: Center.Identity, connected: [31] },
+    { num: 4, center: Center.Ajna, connected: [63] },
+    { num: 29, center: Center.Sacral, connected: [46] },
+    { num: 59, center: Center.Sacral, connected: [6] },
+    { num: 40, center: Center.Will, connected: [37] },
+    { num: 64, center: Center.Head, connected: [47] },
+    { num: 47, center: Center.Ajna, connected: [64] },
+    { num: 6, center: Center.ESP, connected: [59] },
+    { num: 46, center: Center.Identity, connected: [29] },
+    { num: 18, center: Center.Spleen, connected: [58] },
+    { num: 48, center: Center.Spleen, connected: [16] },
+    { num: 57, center: Center.Spleen, connected: [34, 10, 20] },
+    { num: 32, center: Center.Spleen, connected: [54] },
+    { num: 50, center: Center.Spleen, connected: [27] },
+    { num: 28, center: Center.Spleen, connected: [36] },
+    { num: 44, center: Center.Spleen, connected: [26] },
+    { num: 1, center: Center.Identity, connected: [8] },
+    { num: 43, center: Center.Ajna, connected: [23] },
+    { num: 14, center: Center.Sacral, connected: [2] },
+    { num: 34, center: Center.Sacral, connected: [57, 10, 20] },
+    { num: 9, center: Center.Sacral, connected: [52] },
+    { num: 5, center: Center.Sacral, connected: [15] },
+    { num: 26, center: Center.Will, connected: [44] },
+    { num: 11, center: Center.Ajna, connected: [56] },
+    { num: 10, center: Center.Identity, connected: [20, 57, 34] },
+    { num: 58, center: Center.Root, connected: [18] },
+    { num: 38, center: Center.Root, connected: [28] },
+    { num: 54, center: Center.Root, connected: [32] },
+    { num: 61, center: Center.Head, connected: [24] },
+    { num: 60, center: Center.Root, connected: [3] }
+]
 const gates = [
     20, 34, 63, 64, 55, 24, 53, 20, 17, 6, 52, 57, 7, 59, 55, 37, 40, 52, 40, 64, 31, 21, 46, 39,
     57, 4
 ]
 const gatesByCenter = groupBy(item => item.center.toString(), allItems)
 const gateNumbers: Set<number> = new Set(gates)
+const gateNum = ({ num }: TestInterface) => num
 const defined = gateNumbers.has.bind(gateNumbers)
 const uf = unionFind(
     allItems,

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,12 +1,17 @@
 export default {
-    preset: 'ts-jest',
+    preset: 'ts-jest/presets/default-esm',
     testEnvironment: 'node',
     testMatch: ['**/test/**/*.spec.ts'],
     collectCoverageFrom: ['<rootDir>/src/**/*.ts', '!<rootDir>/src/types/**/*.ts'],
     globals: {
         'ts-jest': {
+            useESM: true,
             diagnostics: false,
             isolatedModules: true
         }
-    }
+    },
+    // See https://kulshekhar.github.io/ts-jest/docs/guides/esm-support/#use-esm-presets
+    moduleNameMapper: {
+      '^(\\.{1,2}/.*)\\.js$': '$1',
+    },
 }

--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "union-find-ts",
   "version": "1.0.9",
   "description": "An immutable Union-Find structure.",
-  "main": "./lib/src/index.js",
+  "main": "./lib/index.js",
   "files": [
     "lib/**/*"
   ],
   "type": "module",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --project ./tsconfig.build.json",
     "clean": "rm -rf ./lib/",
     "cm": "cz",
     "coverage": "codecov",

--- a/src/findGroup.ts
+++ b/src/findGroup.ts
@@ -1,6 +1,6 @@
 import { Maybe, Just, Nothing } from 'purify-ts'
 import { any, concat, prepend } from 'ramda'
-import { find, findItem, hasGroup, linkItemAll, UnionFind } from './UnionFind'
+import { find, findItem, hasGroup, linkItemAll, UnionFind } from './UnionFind.js'
 
 interface GroupReducer<T> {
     readonly solutions: Maybe<T[][]>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export * from './UnionFind'
-export * from './findGroup'
+export * from './UnionFind.js'
+export * from './findGroup.js'

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "test/**/*.ts"
+  ],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "declaration": true,
     "outDir": "./lib/",
     "strict": true,
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

- Fixes issues with ESM imports. This made the package unusable in webpack v5 as well as node v14 and v16, as seen below:
  - node v14 / v16:

    ```txt
    node:internal/errors:477
    ErrorCaptureStackTrace(err);
    ^
    Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../node_modules/union-find-ts/lib/src/UnionFind' imported from 
    .../node_modules/union-find-ts/lib/src/index.js
        at new NodeError (node:internal/errors:387:5)
        at finalizeResolution (node:internal/modules/esm/resolve:429:11)
        at moduleResolve (node:internal/modules/esm/resolve:1006:10)
        at defaultResolve (node:internal/modules/esm/resolve:1214:11)
        at nextResolve (node:internal/modules/esm/loader:165:28)
        at ESMLoader.resolve (node:internal/modules/esm/loader:844:30)
        at ESMLoader.getModuleJob (node:internal/modules/esm/loader:431:18)
        at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:76:40)
        at link (node:internal/modules/esm/module_job:75:36) {
      code: 'ERR_MODULE_NOT_FOUND'
    }
    ```

  - webpack v5:
    ```
    ERROR in ./node_modules/union-find-ts/lib/src/index.js 1:0-28
    Module not found: Error: Can't resolve './UnionFind' in '/Users/matt/Projects/union-find-test/node_modules/union-find-ts/lib/src'
    Did you mean 'UnionFind.js'?
    BREAKING CHANGE: The request './UnionFind' failed to resolve only because it was resolved as fully specified
    (probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
    The extension in the request is mandatory for it to be fully specified.
    Add the extension to the request.
    resolve './UnionFind' in '/Users/matt/Projects/union-find-test/node_modules/union-find-ts/lib/src'
      using description file: /Users/matt/Projects/union-find-test/node_modules/union-find-ts/package.json (relative path: ./lib/src)
        Field 'browser' doesn't contain a valid alias configuration
        using description file: /Users/matt/Projects/union-find-test/node_modules/union-find-ts/package.json (relative path: ./lib/src/UnionFind)
          Field 'browser' doesn't contain a valid alias configuration
          /Users/matt/Projects/union-find-test/node_modules/union-find-ts/lib/src/UnionFind doesn't exist
    ```
- Ensures that `npm run test` still works as expected after fixing ESM imports. See https://kulshekhar.github.io/ts-jest/docs/guides/esm-support.
  - This is the error that popped up:
    ```txt
    pnpm run test 

    > union-find-ts@1.0.9 test /Users/matt/Projects/union-find-ts
    > jest --coverage

    FAIL  test/index.spec.ts
      ● Test suite failed to run

        Cannot find module './UnionFind.js' from 'src/index.ts'

        Require stack:
          src/index.ts
          test/index.spec.ts

        > 1 | export * from './UnionFind.js'
            | ^
          2 | export * from './findGroup.js'
          3 |

          at Resolver._throwModNotFoundError (node_modules/.pnpm/jest-resolve@28.1.1/node_modules/jest-resolve/build/resolver.js:491:11)
          at Object.__exportStar (src/index.ts:1:1)

    --------------|---------|----------|---------|---------|-------------------
    File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
    --------------|---------|----------|---------|---------|-------------------
    All files     |       0 |        0 |       0 |       0 |                   
    UnionFind.ts |       0 |        0 |       0 |       0 | 1-257             
    findGroup.ts |       0 |        0 |       0 |       0 | 1-61              
    index.ts     |       0 |      100 |     100 |       0 | 1-2               
    --------------|---------|----------|---------|---------|-------------------
    Test Suites: 1 failed, 1 total
    Tests:       0 total
    Snapshots:   0 total
    Time:        1.028 s
    Ran all test suites.
     ELIFECYCLE  Test failed. See above for more details.
    ```
- Removes the `test` directory from the published `.tgz` archive. See https://unpkg.com/browse/union-find-ts@1.0.9/lib/ for the published `lib` files in v1.0.9.
- Verified these changes by creating a separate npm project with an `index.mjs` file with ESM imports and running `node index.mjs`, as well as with both webpack v5 and webpack v4.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
